### PR TITLE
Fixed app/settings.yaml template to include default models

### DIFF
--- a/src/tpl/app/settings.yaml
+++ b/src/tpl/app/settings.yaml
@@ -14,7 +14,13 @@ background: milkyway
 language: en-GB
 
 # LLM provider
-llm: default
+llm:
+  chat: openai/gpt-4o
+  tools: openai/gpt-4o
+  sentiment: openai/gpt-4o-mini
+  tasks: openai/gpt-4o-mini
+  intent: openai/gpt-4o
+  translation: openai/gpt-4o-mini
 
 # default avatar prompt
 prompt:


### PR DESCRIPTION
This PR addresses a few problems emerged while investigating https://github.com/sermas-eu/sermas-toolkit-api/issues/5

When using ollama without an OpenAPI key, application could silently fallback to OpenAPI calls.

Changes in multiple repos are needed. See first comment.

PRs include:
- Improved logs and some code refactoring
- Reviewed documentation
- Reviewed configuration (changed variable names and defaults)