### PR TITLE
Make CLI programmable as an imported module (needed for testing)

### DIFF
--- a/src/dev.ts
+++ b/src/dev.ts
@@ -2,4 +2,7 @@
 import { CliProgram } from "./cli";
 import logger from "./libs/logger";
 
-new CliProgram().init().catch((e) => logger.error(e.stack));
+const cliProgram = new CliProgram();
+const logStack = (e) => logger.error(e.stack);
+cliProgram.init().catch(logStack);
+cliProgram.parse().catch(logStack);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,7 @@
 import { CliProgram } from "./cli";
 import logger from "./libs/logger";
 
-new CliProgram().init().catch((e) => logger.error(e.stack));
+const cliProgram = new CliProgram();
+const logStack = (e) => logger.error(e.stack);
+cliProgram.init().catch(logStack);
+cliProgram.parse().catch(logStack);


### PR DESCRIPTION
Added .program attribute to CliProgram class. 
Separated init() and parse() methods.

Should I also export CliProgram in index.ts?