### PR TITLE
Feat/batch variations

### DIFF
--- a/src/libs/batch/batch.runner.ts
+++ b/src/libs/batch/batch.runner.ts
@@ -63,7 +63,11 @@ export class BatchRunner {
         if (!matches) continue;
         let originalApp: PlatformAppDto;
         if (modifiedSettings) {
-          // Overriding some app settings
+          logger.debug(
+            `Overriding app ${
+              chatBatch.appId
+            } with the following settings: ${JSON.stringify(modifiedSettings)}`,
+          );
           originalApp = await this.api.loadApp(chatBatch.appId);
           const modifiedApp = structuredClone(originalApp);
           modifiedApp.settings.llm = {

--- a/src/libs/batch/batch.runner.ts
+++ b/src/libs/batch/batch.runner.ts
@@ -57,23 +57,18 @@ export class BatchRunner {
       batchs: [],
     };
 
-    const overrides: Array<AppSettingsDto | null> = [
-      null,
-      { avatar: "Anna", background: "Milkyway" },
-    ];
-
-    for (const settingOverrides of overrides) {
-      for (const chatBatch of chatBatchs) {
+    for (const chatBatch of chatBatchs) {
+      for (const modifiedSettings of chatBatch.settingsOverrides || [null]) {
         const matches = this.matchName(chatBatch, batchName);
         if (!matches) continue;
         let originalApp: PlatformAppDto;
-        if (settingOverrides) {
+        if (modifiedSettings) {
           // Overriding some app settings
           originalApp = await this.api.loadApp(chatBatch.appId);
           const modifiedApp = structuredClone(originalApp);
           modifiedApp.settings.llm = {
             ...modifiedApp.settings.llm,
-            ...(settingOverrides?.llm || {}),
+            ...(modifiedSettings.llm || {}),
           };
           await this.api.updateApp(modifiedApp);
         }
@@ -96,7 +91,7 @@ export class BatchRunner {
 
         await this.saveResults(stats);
 
-        if (settingOverrides && originalApp) {
+        if (modifiedSettings && originalApp) {
           // Restoring original app settings
           this.api.updateApp(originalApp);
           originalApp = undefined;

--- a/src/libs/batch/loader.dto.ts
+++ b/src/libs/batch/loader.dto.ts
@@ -19,4 +19,5 @@ export type ChatBatch = {
   settings?: Partial<AppSettingsDto>;
   wait?: number;
   chat: ChatBatchMessage[];
+  settingsOverrides?: Partial<AppSettingsDto>[];
 };

--- a/src/libs/batch/loader.ts
+++ b/src/libs/batch/loader.ts
@@ -63,17 +63,9 @@ export const loadChatBatch = async (dir: string, skipRepository = false) => {
       continue;
     }
 
-    yaml.filePath = item;
-    yaml.name = item.split("/").pop().split(".").slice(0, -1).join(".");
-
     if (!yaml.appId) {
       yaml.appId = appId;
     }
-
-    yaml.settings = {
-      ...(settings || {}),
-      ...(yaml.settings || {}),
-    };
 
     if (!yaml.appId) {
       logger.warn(`appId is missing in file ${item}, skipping.`);
@@ -84,6 +76,13 @@ export const loadChatBatch = async (dir: string, skipRepository = false) => {
       logger.warn(`missing chat elements in file ${item}, skipping.`);
       continue;
     }
+
+    yaml.filePath = item;
+    yaml.name = item.split("/").pop().split(".").slice(0, -1).join(".");
+    yaml.settings = {
+      ...(settings || {}),
+      ...(yaml.settings || {}),
+    };
 
     definitions.push(yaml);
   }


### PR DESCRIPTION
This allows you to change the App `llm` settings within a test, thus testing different providers for the same test.

To do so, you must add a settingsOverrides attribute in the yaml test description:

```yaml
# ...
settingsOverrides:
  - llm:
      chat: openai/gpt-4o
  - llm:
      chat: gcp_mistral/mistral-small-2503
```
A separate test will be run for each override. If no override is provided, normal app settings are used.
